### PR TITLE
Migrate notification seen/allSeen to v2 API

### DIFF
--- a/router/routes.go
+++ b/router/routes.go
@@ -604,6 +604,28 @@ func SetupRoutes(app *fiber.App) {
 		// @Success 200 {array} notification.Notification
 		rg.Get("/notification", notification.List)
 
+		// Mark notification as seen
+		// @Router /notification/seen [post]
+		// @Summary Mark notification as seen
+		// @Description Marks a specific notification as seen for the authenticated user
+		// @Tags notification
+		// @Accept json
+		// @Produce json
+		// @Security BearerAuth
+		// @Param body body notification.SeenRequest true "Notification ID"
+		// @Success 200 {object} map[string]interface{}
+		rg.Post("/notification/seen", notification.Seen)
+
+		// Mark all notifications as seen
+		// @Router /notification/allseen [post]
+		// @Summary Mark all notifications as seen
+		// @Description Marks all notifications as seen for the authenticated user
+		// @Tags notification
+		// @Produce json
+		// @Security BearerAuth
+		// @Success 200 {object} map[string]interface{}
+		rg.Post("/notification/allseen", notification.AllSeen)
+
 		// Online Status
 		// @Router /online [get]
 		// @Summary Check online status

--- a/test/notifications_test.go
+++ b/test/notifications_test.go
@@ -1,7 +1,9 @@
 package test
 
 import (
+	"bytes"
 	json2 "encoding/json"
+	"fmt"
 	"github.com/freegle/iznik-server-go/notification"
 	"github.com/stretchr/testify/assert"
 	"net/http/httptest"
@@ -30,4 +32,89 @@ func TestNotifications(t *testing.T) {
 
 	json2.Unmarshal(rsp(resp), &notifications)
 	assert.GreaterOrEqual(t, uint64(len(notifications)), count.Count)
+}
+
+func TestNotificationSeen(t *testing.T) {
+	prefix := uniquePrefix("notif_seen")
+
+	// Create user and get token
+	userID := CreateTestUser(t, prefix, "User")
+	fromUserID := CreateTestUser(t, prefix+"_from", "User")
+	_, token := CreateTestSession(t, userID)
+
+	// Create a notification
+	notifID := CreateTestNotification(t, userID, fromUserID, "Comment")
+
+	// Mark it as seen
+	body := fmt.Sprintf(`{"id": %d}`, notifID)
+	req := httptest.NewRequest("POST", "/api/notification/seen?jwt="+token, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, true, result["success"])
+}
+
+func TestNotificationSeenUnauthorized(t *testing.T) {
+	// Test without token - should fail
+	body := `{"id": 1}`
+	req := httptest.NewRequest("POST", "/api/notification/seen", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestNotificationSeenInvalidBody(t *testing.T) {
+	prefix := uniquePrefix("notif_invalid")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	// Test with missing ID
+	body := `{}`
+	req := httptest.NewRequest("POST", "/api/notification/seen?jwt="+token, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestNotificationAllSeen(t *testing.T) {
+	prefix := uniquePrefix("notif_allseen")
+
+	// Create user and get token
+	userID := CreateTestUser(t, prefix, "User")
+	fromUserID := CreateTestUser(t, prefix+"_from", "User")
+	_, token := CreateTestSession(t, userID)
+
+	// Create multiple notifications
+	CreateTestNotification(t, userID, fromUserID, "Comment")
+	CreateTestNotification(t, userID, fromUserID, "Loved")
+
+	// Mark all as seen
+	req := httptest.NewRequest("POST", "/api/notification/allseen?jwt="+token, nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, true, result["success"])
+
+	// Verify count is now 0
+	resp, _ = getApp().Test(httptest.NewRequest("GET", "/api/notification/count?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	type Count struct {
+		Count uint64
+	}
+	var count Count
+	json2.Unmarshal(rsp(resp), &count)
+	assert.Equal(t, uint64(0), count.Count)
+}
+
+func TestNotificationAllSeenUnauthorized(t *testing.T) {
+	// Test without token - should fail
+	req := httptest.NewRequest("POST", "/api/notification/allseen", nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 401, resp.StatusCode)
 }


### PR DESCRIPTION
## Summary
- Add POST /notification/seen endpoint for marking a specific notification as seen
- Add POST /notification/allseen endpoint for marking all notifications as seen
- Add CreateTestNotification factory function for tests
- Add comprehensive tests for new endpoints

## Test plan
- [x] Tests added for success cases
- [x] Tests added for unauthorized access (401)
- [x] Tests added for invalid body (400)
- [x] Tests verify notification count updates correctly

Part of v1 to v2 API migration (Phase 0.2 - non-email write operations).