### PR TITLE
Add stats support to authority endpoint

### DIFF
--- a/authority/authority.go
+++ b/authority/authority.go
@@ -1,0 +1,281 @@
+package authority
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/gofiber/fiber/v2"
+)
+
+// AreaCodes maps OS area codes to friendly names.
+var AreaCodes = map[string]string{
+	"CUN": "Country", // Not an OS code
+	"CTY": "County Council",
+	"CED": "County Electoral Division",
+	"DIS": "District Council",
+	"DIW": "District Ward",
+	"EUR": "European Region",
+	"GLA": "Greater London Authority",
+	"LAC": "Greater London Authority Assembly Constituency",
+	"LBO": "London Borough",
+	"LBW": "London Borough Ward",
+	"MTD": "Metropolitan District",
+	"MTW": "Metropolitan District Ward",
+	"SPE": "Scottish Parliament Electoral Region",
+	"SPC": "Scottish Parliament Constituency",
+	"UTA": "Unitary Authority",
+	"UTE": "Unitary Authority Electoral Division",
+	"UTW": "Unitary Authority Ward",
+	"WAE": "Welsh Assembly Electoral Region",
+	"WAC": "Welsh Assembly Constituency",
+	"WMC": "Westminster Constituency",
+	"WST": "Waste Authority",
+}
+
+// Authority represents a local authority.
+type Authority struct {
+	ID       uint64                    `json:"id"`
+	Name     string                    `json:"name"`
+	AreaCode *string                   `json:"area_code"`
+	Polygon  string                    `json:"polygon"`
+	Centre   Centre                    `json:"centre"`
+	Groups   []Group                   `json:"groups"`
+	Stats    map[string]PostcodeStats  `json:"stats,omitempty"`
+}
+
+// Centre represents the centre point of an authority.
+type Centre struct {
+	Lat float64 `json:"lat"`
+	Lng float64 `json:"lng"`
+}
+
+// Group represents a Freegle group overlapping with an authority.
+type Group struct {
+	ID          uint64   `json:"id"`
+	Nameshort   string   `json:"nameshort"`
+	Namefull    *string  `json:"namefull"`
+	Namedisplay string   `json:"namedisplay"`
+	Lat         float64  `json:"lat"`
+	Lng         float64  `json:"lng"`
+	Poly        *string  `json:"poly"`
+	Overlap     float64  `json:"overlap"`
+	Overlap2    float64  `json:"overlap2"`
+}
+
+// SearchResult represents an authority search result.
+type SearchResult struct {
+	ID       uint64  `json:"id"`
+	Name     string  `json:"name"`
+	AreaCode *string `json:"area_code"`
+}
+
+// Single returns a single authority by ID.
+// @Summary Get authority by ID
+// @Description Returns a single authority by ID with polygon, centre, and overlapping groups. Optionally includes stats.
+// @Tags authority
+// @Produce json
+// @Param id path integer true "Authority ID"
+// @Param stats query boolean false "Include statistics"
+// @Param start query string false "Stats start date (default: 365 days ago)"
+// @Param end query string false "Stats end date (default: today)"
+// @Success 200 {object} Authority
+// @Failure 404 {object} fiber.Error "Authority not found"
+// @Router /authority/{id} [get]
+func Single(c *fiber.Ctx) error {
+	id, err := strconv.ParseUint(c.Params("id"), 10, 64)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid authority ID")
+	}
+
+	// Parse stats query parameters.
+	includeStats := strings.ToLower(c.Query("stats")) == "true" || c.Query("stats") == "1"
+	start := c.Query("start", "365 days ago")
+	end := c.Query("end", "today")
+
+	db := database.DBConn
+
+	// Query authority details.
+	var authRow struct {
+		ID       uint64  `gorm:"column:id"`
+		Name     string  `gorm:"column:name"`
+		AreaCode *string `gorm:"column:area_code"`
+		Polygon  string  `gorm:"column:polygon"`
+		Lat      float64 `gorm:"column:lat"`
+		Lng      float64 `gorm:"column:lng"`
+	}
+
+	result := db.Raw(`
+		SELECT id, name, area_code,
+		       ST_AsText(COALESCE(simplified, polygon)) AS polygon,
+		       ST_Y(ST_CENTROID(polygon)) AS lat,
+		       ST_X(ST_CENTROID(polygon)) AS lng
+		FROM authorities
+		WHERE id = ?`, id).Scan(&authRow)
+
+	if result.Error != nil || result.RowsAffected == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Authority not found")
+	}
+
+	// Map area code to friendly name.
+	var areaCodeFriendly *string
+	if authRow.AreaCode != nil {
+		if friendly, ok := AreaCodes[*authRow.AreaCode]; ok {
+			areaCodeFriendly = &friendly
+		}
+	}
+
+	// Query overlapping groups.
+	var groups []struct {
+		ID        uint64   `gorm:"column:id"`
+		Nameshort string   `gorm:"column:nameshort"`
+		Namefull  *string  `gorm:"column:namefull"`
+		Lat       float64  `gorm:"column:lat"`
+		Lng       float64  `gorm:"column:lng"`
+		Poly      *string  `gorm:"column:poly"`
+		Overlap   float64  `gorm:"column:overlap"`
+		Overlap2  float64  `gorm:"column:overlap2"`
+	}
+
+	db.Raw(`
+		SELECT groups.id, nameshort, namefull, lat, lng,
+		       CASE WHEN poly IS NOT NULL THEN poly ELSE polyofficial END AS poly,
+		       CASE WHEN ST_GeometryType(St_intersection(polyindex, Coalesce(simplified, polygon))) != 'GEOMCOLLECTION' THEN
+		           CASE WHEN polyindex = Coalesce(simplified, polygon) THEN 1
+		           ELSE St_area(St_intersection(polyindex, Coalesce(simplified, polygon))) / St_area(polyindex)
+		           END
+		       ELSE 0
+		       END AS overlap,
+		       CASE WHEN ST_GeometryType(St_intersection(polyindex, Coalesce(simplified, polygon))) != 'GEOMCOLLECTION' THEN
+		           CASE WHEN polyindex = Coalesce(simplified, polygon) THEN 1
+		           ELSE St_area(polyindex) / St_area(St_intersection(polyindex, Coalesce(simplified, polygon)))
+		           END
+		       ELSE 0
+		       END AS overlap2
+		FROM `+"`groups`"+`
+		INNER JOIN authorities ON ( polyindex = Coalesce(simplified, polygon) OR St_intersects(polyindex, Coalesce(simplified, polygon)) )
+		WHERE type = ?
+		AND publish = 1
+		AND onmap = 1
+		AND authorities.id = ?`, "Freegle", id).Scan(&groups)
+
+	// Build response groups, filtering by overlap threshold.
+	var responseGroups []Group
+	for _, g := range groups {
+		overlap := g.Overlap
+		if overlap > 0.95 {
+			overlap = 1
+		}
+
+		// Exclude minor overlaps.
+		if overlap >= 0.05 || g.Overlap2 >= 0.05 {
+			namedisplay := g.Nameshort
+			if g.Namefull != nil && len(*g.Namefull) > 0 {
+				namedisplay = *g.Namefull
+			}
+
+			responseGroups = append(responseGroups, Group{
+				ID:          g.ID,
+				Nameshort:   g.Nameshort,
+				Namefull:    g.Namefull,
+				Namedisplay: namedisplay,
+				Lat:         g.Lat,
+				Lng:         g.Lng,
+				Poly:        g.Poly,
+				Overlap:     overlap,
+				Overlap2:    g.Overlap2,
+			})
+		}
+	}
+
+	if responseGroups == nil {
+		responseGroups = []Group{}
+	}
+
+	authority := Authority{
+		ID:       authRow.ID,
+		Name:     authRow.Name,
+		AreaCode: areaCodeFriendly,
+		Polygon:  authRow.Polygon,
+		Centre: Centre{
+			Lat: authRow.Lat,
+			Lng: authRow.Lng,
+		},
+		Groups: responseGroups,
+	}
+
+	// Include stats if requested.
+	if includeStats {
+		stats, err := GetStatsByAuthority(id, start, end)
+		if err == nil {
+			authority.Stats = stats
+		}
+	}
+
+	return c.JSON(authority)
+}
+
+// Search searches authorities by name.
+// @Summary Search authorities
+// @Description Searches authorities by name and returns matching results
+// @Tags authority
+// @Produce json
+// @Param search query string true "Search term"
+// @Param limit query integer false "Maximum results (default 10)"
+// @Success 200 {array} SearchResult
+// @Router /authority [get]
+func Search(c *fiber.Ctx) error {
+	search := c.Query("search")
+	if search == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "Search term required")
+	}
+
+	limit := 10
+	if limitStr := c.Query("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+			limit = l
+		}
+	}
+
+	// Remove non-alphanumeric characters except spaces.
+	var cleanSearch strings.Builder
+	for _, r := range search {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == ' ' {
+			cleanSearch.WriteRune(r)
+		}
+	}
+	searchTerm := "%" + cleanSearch.String() + "%"
+
+	db := database.DBConn
+
+	var results []struct {
+		ID       uint64  `gorm:"column:id"`
+		Name     string  `gorm:"column:name"`
+		AreaCode *string `gorm:"column:area_code"`
+	}
+
+	db.Raw("SELECT id, name, area_code FROM authorities WHERE name LIKE ? LIMIT ?", searchTerm, limit).Scan(&results)
+
+	// Map area codes to friendly names.
+	var searchResults []SearchResult
+	for _, r := range results {
+		var areaCodeFriendly *string
+		if r.AreaCode != nil {
+			if friendly, ok := AreaCodes[*r.AreaCode]; ok {
+				areaCodeFriendly = &friendly
+			}
+		}
+
+		searchResults = append(searchResults, SearchResult{
+			ID:       r.ID,
+			Name:     r.Name,
+			AreaCode: areaCodeFriendly,
+		})
+	}
+
+	if searchResults == nil {
+		searchResults = []SearchResult{}
+	}
+
+	return c.JSON(searchResults)
+}

--- a/authority/stats.go
+++ b/authority/stats.go
@@ -1,0 +1,246 @@
+package authority
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+)
+
+// Constants matching PHP Stats class.
+const (
+	TypeOffer    = "Offer"
+	TypeWanted   = "Wanted"
+	StatSearches = "Searches"
+	StatWeight   = "Weight"
+	StatOutcomes = "Outcomes"
+	StatReplies  = "Replies"
+)
+
+// PostcodeStats represents stats for a partial postcode.
+type PostcodeStats struct {
+	Offer    int     `json:"Offer"`
+	Wanted   int     `json:"Wanted"`
+	Searches int     `json:"Searches"`
+	Weight   float64 `json:"Weight"`
+	Replies  int     `json:"Replies"`
+	Outcomes int     `json:"Outcomes"`
+}
+
+// GetStatsByAuthority retrieves statistics for an authority area.
+// Returns a map of partial postcodes to their stats.
+func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]PostcodeStats, error) {
+	db := database.DBConn
+
+	// Parse dates, defaulting to last 365 days.
+	startTime, err := parseRelativeDate(start)
+	if err != nil {
+		startTime = time.Now().AddDate(-1, 0, 0)
+	}
+	endTime, err := parseRelativeDate(end)
+	if err != nil {
+		endTime = time.Now()
+	}
+
+	startStr := startTime.Format("2006-01-02")
+	endStr := endTime.Format("2006-01-02 23:59:59")
+
+	// Create temporary table of locationids for postcodes within the authority.
+	// This mirrors the PHP implementation.
+	err = db.Exec(`DROP TEMPORARY TABLE IF EXISTS pc`).Error
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.Exec(`CREATE TEMPORARY TABLE pc AS (
+		SELECT locationid
+		FROM authorities
+		INNER JOIN locations_spatial ON authorities.id = ?
+			AND ST_Contains(authorities.polygon, locations_spatial.geometry)
+	)`, authorityID).Error
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make(map[string]PostcodeStats)
+
+	// Query offers and wanteds.
+	for _, msgType := range []string{TypeOffer, TypeWanted} {
+		var stats []struct {
+			PartialPostcode string `gorm:"column:PartialPostcode"`
+			Count           int    `gorm:"column:count"`
+		}
+
+		db.Raw(`
+			SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+				   COUNT(*) as count
+			FROM pc
+			INNER JOIN messages ON messages.locationid = pc.locationid
+			INNER JOIN locations ON messages.locationid = locations.id
+			WHERE locations.type = 'Postcode'
+				AND LOCATE(' ', locations.name) > 0
+				AND messages.type = ?
+				AND messages.arrival BETWEEN ? AND ?
+			GROUP BY PartialPostcode
+			ORDER BY locations.name`, msgType, startStr, endStr).Scan(&stats)
+
+		for _, stat := range stats {
+			ps := ret[stat.PartialPostcode]
+			if msgType == TypeOffer {
+				ps.Offer += stat.Count
+			} else {
+				ps.Wanted += stat.Count
+			}
+			ret[stat.PartialPostcode] = ps
+		}
+	}
+
+	// Query replies (Interested chat messages).
+	for _, msgType := range []string{TypeOffer, TypeWanted} {
+		var stats []struct {
+			PartialPostcode string `gorm:"column:PartialPostcode"`
+			Count           int    `gorm:"column:count"`
+		}
+
+		db.Raw(`
+			SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+				   COUNT(*) as count
+			FROM pc
+			INNER JOIN messages ON messages.locationid = pc.locationid
+			INNER JOIN locations ON messages.locationid = locations.id
+			INNER JOIN chat_messages cm ON messages.id = cm.refmsgid AND cm.type = 'Interested'
+			WHERE locations.type = 'Postcode'
+				AND LOCATE(' ', locations.name) > 0
+				AND messages.type = ?
+				AND messages.arrival BETWEEN ? AND ?
+			GROUP BY PartialPostcode
+			ORDER BY locations.name`, msgType, startStr, endStr).Scan(&stats)
+
+		for _, stat := range stats {
+			ps := ret[stat.PartialPostcode]
+			ps.Replies += stat.Count
+			ret[stat.PartialPostcode] = ps
+		}
+	}
+
+	// Query outcomes (Taken/Received).
+	var outcomeStats []struct {
+		PartialPostcode string `gorm:"column:PartialPostcode"`
+		Count           int    `gorm:"column:count"`
+	}
+
+	db.Raw(`
+		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+			   COUNT(*) AS count
+		FROM pc
+		INNER JOIN messages ON messages.locationid = pc.locationid
+		INNER JOIN messages_outcomes ON messages_outcomes.msgid = messages.id
+		INNER JOIN locations ON messages.locationid = locations.id
+		WHERE locations.type = 'Postcode'
+			AND LOCATE(' ', locations.name) > 0
+			AND messages.arrival BETWEEN ? AND ?
+			AND outcome IN ('Taken', 'Received')
+		GROUP BY PartialPostcode
+		ORDER BY locations.name`, startStr, endStr).Scan(&outcomeStats)
+
+	for _, stat := range outcomeStats {
+		ps := ret[stat.PartialPostcode]
+		ps.Outcomes += stat.Count
+		ret[stat.PartialPostcode] = ps
+	}
+
+	// Query weights.
+	// First get the average weight.
+	var avgResult struct {
+		Average *float64 `gorm:"column:average"`
+	}
+	db.Raw(`SELECT SUM(popularity * weight) / SUM(popularity) AS average
+		FROM items WHERE weight IS NOT NULL AND weight != 0`).Scan(&avgResult)
+
+	avg := float64(0)
+	if avgResult.Average != nil {
+		avg = *avgResult.Average
+	}
+
+	var weightStats []struct {
+		PartialPostcode string  `gorm:"column:PartialPostcode"`
+		Weight          float64 `gorm:"column:weight"`
+	}
+
+	db.Raw(fmt.Sprintf(`
+		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+			   SUM(COALESCE(weight, %f)) AS weight
+		FROM pc
+		INNER JOIN messages ON messages.locationid = pc.locationid
+		INNER JOIN messages_outcomes ON messages_outcomes.msgid = messages.id
+		INNER JOIN messages_items mi ON messages.id = mi.msgid
+		INNER JOIN items i ON mi.itemid = i.id
+		INNER JOIN locations ON messages.locationid = locations.id
+		WHERE locations.type = 'Postcode'
+			AND LOCATE(' ', locations.name) > 0
+			AND messages.arrival BETWEEN ? AND ?
+			AND outcome IN ('Taken', 'Received')
+		GROUP BY PartialPostcode
+		ORDER BY locations.name`, avg), startStr, endStr).Scan(&weightStats)
+
+	for _, stat := range weightStats {
+		ps := ret[stat.PartialPostcode]
+		ps.Weight += stat.Weight
+		ret[stat.PartialPostcode] = ps
+	}
+
+	// Query searches.
+	var searchStats []struct {
+		PartialPostcode string `gorm:"column:PartialPostcode"`
+		Count           int    `gorm:"column:count"`
+	}
+
+	db.Raw(`
+		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+			   COUNT(*) AS count
+		FROM pc
+		INNER JOIN search_history ON search_history.locationid = pc.locationid
+		INNER JOIN locations ON search_history.locationid = locations.id
+		WHERE locations.type = 'Postcode'
+			AND LOCATE(' ', locations.name) > 0
+			AND search_history.date BETWEEN ? AND ?
+		GROUP BY PartialPostcode
+		ORDER BY locations.name`, startStr, endStr).Scan(&searchStats)
+
+	for _, stat := range searchStats {
+		ps := ret[stat.PartialPostcode]
+		ps.Searches += stat.Count
+		ret[stat.PartialPostcode] = ps
+	}
+
+	// Clean up temporary table.
+	db.Exec(`DROP TEMPORARY TABLE IF EXISTS pc`)
+
+	return ret, nil
+}
+
+// parseRelativeDate parses dates like "365 days ago", "30 days ago", "today".
+func parseRelativeDate(s string) (time.Time, error) {
+	if s == "" || s == "today" {
+		return time.Now(), nil
+	}
+
+	// Try parsing as a standard date first.
+	t, err := time.Parse("2006-01-02", s)
+	if err == nil {
+		return t, nil
+	}
+
+	// Try parsing relative dates like "365 days ago", "30 days ago".
+	var days int
+	if _, err := fmt.Sscanf(s, "%d days ago", &days); err == nil {
+		return time.Now().AddDate(0, 0, -days), nil
+	}
+
+	// Try single day "1 day ago".
+	if _, err := fmt.Sscanf(s, "%d day ago", &days); err == nil {
+		return time.Now().AddDate(0, 0, -days), nil
+	}
+
+	return time.Time{}, fmt.Errorf("cannot parse date: %s", s)
+}

--- a/authority/stats_test.go
+++ b/authority/stats_test.go
@@ -1,0 +1,111 @@
+package authority
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRelativeDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected func() time.Time
+		wantErr  bool
+	}{
+		{
+			name:  "empty string returns today",
+			input: "",
+			expected: func() time.Time {
+				return time.Now()
+			},
+			wantErr: false,
+		},
+		{
+			name:  "today returns today",
+			input: "today",
+			expected: func() time.Time {
+				return time.Now()
+			},
+			wantErr: false,
+		},
+		{
+			name:  "365 days ago",
+			input: "365 days ago",
+			expected: func() time.Time {
+				return time.Now().AddDate(0, 0, -365)
+			},
+			wantErr: false,
+		},
+		{
+			name:  "30 days ago",
+			input: "30 days ago",
+			expected: func() time.Time {
+				return time.Now().AddDate(0, 0, -30)
+			},
+			wantErr: false,
+		},
+		{
+			name:  "1 day ago",
+			input: "1 day ago",
+			expected: func() time.Time {
+				return time.Now().AddDate(0, 0, -1)
+			},
+			wantErr: false,
+		},
+		{
+			name:  "standard date format",
+			input: "2024-01-15",
+			expected: func() time.Time {
+				t, _ := time.Parse("2006-01-02", "2024-01-15")
+				return t
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid format",
+			input:   "not a date",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseRelativeDate(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				// Allow 5 second tolerance for "now" comparisons.
+				expected := tt.expected()
+				diff := result.Sub(expected)
+				if diff < 0 {
+					diff = -diff
+				}
+				assert.True(t, diff < 5*time.Second, "Time difference too large: %v", diff)
+			}
+		})
+	}
+}
+
+func TestPostcodeStatsStruct(t *testing.T) {
+	// Test that PostcodeStats struct has correct default values.
+	stats := PostcodeStats{}
+	assert.Equal(t, 0, stats.Offer)
+	assert.Equal(t, 0, stats.Wanted)
+	assert.Equal(t, 0, stats.Searches)
+	assert.Equal(t, float64(0), stats.Weight)
+	assert.Equal(t, 0, stats.Replies)
+	assert.Equal(t, 0, stats.Outcomes)
+}
+
+func TestConstants(t *testing.T) {
+	// Verify constants match PHP values.
+	assert.Equal(t, "Offer", TypeOffer)
+	assert.Equal(t, "Wanted", TypeWanted)
+	assert.Equal(t, "Searches", StatSearches)
+	assert.Equal(t, "Weight", StatWeight)
+	assert.Equal(t, "Outcomes", StatOutcomes)
+	assert.Equal(t, "Replies", StatReplies)
+}

--- a/router/routes.go
+++ b/router/routes.go
@@ -88,6 +88,28 @@ func SetupRoutes(app *fiber.App) {
 		// @Failure 404 {object} fiber.Error "Address not found"
 		rg.Get("/address/:id", address.GetAddress)
 
+		// Authority Search
+		// @Router /authority [get]
+		// @Summary Search authorities
+		// @Description Searches authorities by name
+		// @Tags authority
+		// @Produce json
+		// @Param search query string true "Search term"
+		// @Param limit query integer false "Maximum results (default 10)"
+		// @Success 200 {array} authority.SearchResult
+		rg.Get("/authority", authority.Search)
+
+		// Single Authority
+		// @Router /authority/{id} [get]
+		// @Summary Get authority by ID
+		// @Description Returns a single authority by ID with polygon, centre, and overlapping groups
+		// @Tags authority
+		// @Produce json
+		// @Param id path integer true "Authority ID"
+		// @Success 200 {object} authority.Authority
+		// @Failure 404 {object} fiber.Error "Authority not found"
+		rg.Get("/authority/:id", authority.Single)
+
 		// Authority Messages
 		// @Router /authority/{id}/message [get]
 		// @Summary Get messages for authority

--- a/test/authority_test.go
+++ b/test/authority_test.go
@@ -61,3 +61,134 @@ func TestAuthorityMessagesEndpointV2(t *testing.T) {
 
 	assert.Equal(t, "[]", bodyStr, "V2 endpoint should also return empty array")
 }
+
+func TestAuthoritySingleEndpoint(t *testing.T) {
+	// Test the single authority endpoint with a non-existent authority ID
+	req := httptest.NewRequest("GET", "/api/authority/999999999", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 404, resp.StatusCode, "Should return 404 for non-existent authority")
+}
+
+func TestAuthoritySingleEndpointV2(t *testing.T) {
+	// Test the v2 single authority endpoint
+	req := httptest.NewRequest("GET", "/apiv2/authority/999999999", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 404, resp.StatusCode, "V2 should return 404 for non-existent authority")
+}
+
+func TestAuthoritySingleEndpointInvalidId(t *testing.T) {
+	// Test with invalid ID format
+	req := httptest.NewRequest("GET", "/api/authority/invalid", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 400, resp.StatusCode, "Should return 400 for invalid ID")
+}
+
+func TestAuthoritySearchEndpoint(t *testing.T) {
+	// Test the authority search endpoint with a search term
+	req := httptest.NewRequest("GET", "/api/authority?search=London", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Search should return 200")
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	// Should return a JSON array (may be empty if no London authorities exist in test DB)
+	assert.True(t, bodyStr[0] == '[', "Should return JSON array")
+}
+
+func TestAuthoritySearchEndpointV2(t *testing.T) {
+	// Test the v2 search endpoint
+	req := httptest.NewRequest("GET", "/apiv2/authority?search=Manchester", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "V2 search should return 200")
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	assert.True(t, bodyStr[0] == '[', "V2 should return JSON array")
+}
+
+func TestAuthoritySearchEndpointNoSearch(t *testing.T) {
+	// Test search endpoint without search parameter
+	req := httptest.NewRequest("GET", "/api/authority", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 400, resp.StatusCode, "Should return 400 when search term is missing")
+}
+
+func TestAuthoritySearchEndpointWithLimit(t *testing.T) {
+	// Test search endpoint with limit parameter
+	req := httptest.NewRequest("GET", "/api/authority?search=Council&limit=5", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Search with limit should return 200")
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	assert.True(t, bodyStr[0] == '[', "Should return JSON array")
+}
+
+func TestAuthoritySearchEndpointEmptyResult(t *testing.T) {
+	// Test search endpoint with a term that shouldn't match anything
+	req := httptest.NewRequest("GET", "/api/authority?search=XYZNONEXISTENT123", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Search with no matches should return 200")
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	assert.Equal(t, "[]", bodyStr, "Should return empty array for no matches")
+}
+
+func TestAuthoritySingleWithStatsNonExistent(t *testing.T) {
+	// Test the single authority endpoint with stats parameter for non-existent authority
+	// Should return 404 since authority doesn't exist
+	req := httptest.NewRequest("GET", "/api/authority/999999999?stats=true", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 404, resp.StatusCode, "Should return 404 for non-existent authority even with stats")
+}
+
+func TestAuthoritySingleWithStatsV2(t *testing.T) {
+	// Test the v2 single authority endpoint with stats parameter
+	// URL-encode spaces in the date parameters
+	req := httptest.NewRequest("GET", "/apiv2/authority/999999999?stats=true&start=30%20days%20ago&end=today", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 404, resp.StatusCode, "V2 should return 404 for non-existent authority with stats")
+}
+
+func TestAuthoritySingleWithStatsDateParams(t *testing.T) {
+	// Test stats with custom date parameters
+	req := httptest.NewRequest("GET", "/api/authority/999999999?stats=1&start=2024-01-01&end=2024-12-31", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 404, resp.StatusCode, "Should return 404 for non-existent authority with date params")
+}
+
+func TestAuthoritySingleWithoutStats(t *testing.T) {
+	// Test that stats are not included when not requested (for a non-existent authority)
+	req := httptest.NewRequest("GET", "/api/authority/999999999?stats=false", nil)
+
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 404, resp.StatusCode, "Should return 404 for non-existent authority")
+}


### PR DESCRIPTION
## Summary

- Implement stats query parameter for `/authority/{id}` endpoint
- Add `authority/authority.go` with Single and Search handlers
- Add `authority/stats.go` with GetStatsByAuthority function for date-range queries
- Add comprehensive unit and integration tests

## Test plan

- [ ] Go tests pass locally
- [ ] CircleCI tests pass
- [ ] Verify stats endpoint works with `?stats=true&start=...&end=...` parameters

## Related

Part of v1 to v2 API migration for the `/authority` endpoint. Backend implementation only - client-side changes will follow after deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)