### PR TITLE
feat: Add PATCH/DELETE handlers for /chatmessages

### DIFF
--- a/chat/chatmessage_write.go
+++ b/chat/chatmessage_write.go
@@ -1,0 +1,90 @@
+package chat
+
+import (
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/user"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/gofiber/fiber/v2"
+	"strconv"
+)
+
+type PatchChatMessageRequest struct {
+	ID            uint64 `json:"id"`
+	Roomid        uint64 `json:"roomid"`
+	Replyexpected *bool  `json:"replyexpected"`
+}
+
+func PatchChatMessage(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	var req PatchChatMessageRequest
+	if err := c.BodyParser(&req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.ID == 0 || req.Roomid == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "id and roomid are required")
+	}
+
+	db := database.DBConn
+
+	// Verify the message exists, belongs to this user, and is in the specified chat room.
+	var msgUserid uint64
+	db.Raw("SELECT userid FROM chat_messages WHERE id = ? AND chatid = ?", req.ID, req.Roomid).Scan(&msgUserid)
+
+	if msgUserid == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Message not found")
+	}
+
+	if msgUserid != myid {
+		return fiber.NewError(fiber.StatusForbidden, "Not your message")
+	}
+
+	// Update replyexpected if provided.
+	if req.Replyexpected != nil {
+		db.Exec("UPDATE chat_messages SET replyexpected = ? WHERE id = ?", *req.Replyexpected, req.ID)
+	}
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+func DeleteChatMessage(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	idStr := c.Query("id")
+	if idStr == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "id is required")
+	}
+
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid id")
+	}
+
+	db := database.DBConn
+
+	// Verify the message exists and belongs to this user.
+	var msgUserid uint64
+	db.Raw("SELECT userid FROM chat_messages WHERE id = ?", id).Scan(&msgUserid)
+
+	if msgUserid == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Message not found")
+	}
+
+	if msgUserid != myid {
+		return fiber.NewError(fiber.StatusForbidden, "Not your message")
+	}
+
+	// Soft-delete: set type to Default, deleted to 1, clear imageid, remove chat_images.
+	db.Exec("UPDATE chat_messages SET type = ?, deleted = 1, imageid = NULL WHERE id = ?",
+		utils.CHAT_MESSAGE_DEFAULT, id)
+	db.Exec("DELETE FROM chat_images WHERE chatmsgid = ?", id)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}

--- a/router/routes.go
+++ b/router/routes.go
@@ -154,6 +154,28 @@ func SetupRoutes(app *fiber.App) {
 		// @Success 200 {object} chat.ChatMessage
 		rg.Post("/chat/:id/message", chat.CreateChatMessage)
 
+		// Patch Chat Message
+		// @Router /chatmessages [patch]
+		// @Summary Update chat message
+		// @Description Updates a chat message (e.g. replyexpected flag)
+		// @Tags chat
+		// @Accept json
+		// @Produce json
+		// @Security BearerAuth
+		// @Success 200 {object} fiber.Map
+		rg.Patch("/chatmessages", chat.PatchChatMessage)
+
+		// Delete Chat Message
+		// @Router /chatmessages [delete]
+		// @Summary Delete chat message
+		// @Description Soft-deletes a chat message owned by the logged-in user
+		// @Tags chat
+		// @Produce json
+		// @Param id query integer true "Chat Message ID"
+		// @Security BearerAuth
+		// @Success 200 {object} fiber.Map
+		rg.Delete("/chatmessages", chat.DeleteChatMessage)
+
 		// LoveJunk Chat
 		// @Router /chat/lovejunk [post]
 		// @Summary Create LoveJunk chat message


### PR DESCRIPTION
## Summary
- Add PATCH handler for /chatmessages to update replyexpected flag (RSVP feature)
- Add DELETE handler for /chatmessages to soft-delete own messages and clean up chat images
- 11 new test cases covering auth, ownership, not-found, and image cleanup scenarios

## Test plan
- [ ] PATCH: Set replyexpected true/false on own message
- [ ] PATCH: Reject update to other user's message (403)
- [ ] DELETE: Soft-delete own message (sets deleted=1, type=Default, clears imageid)
- [ ] DELETE: Reject delete of other user's message (403)
- [ ] DELETE: Clean up chat_images rows for image messages