### PR TITLE
feat: Add GET /comment handler

### DIFF
--- a/router/routes.go
+++ b/router/routes.go
@@ -364,6 +364,18 @@ func SetupRoutes(app *fiber.App) {
 		rg.Patch("/communityevent", communityevent.Update)
 		rg.Delete("/communityevent/:id", communityevent.Delete)
 
+		// Comment
+		// @Router /comment [get]
+		// @Summary List or get comments
+		// @Description Returns comments for moderated groups, with pagination. Pass id for a single comment.
+		// @Tags comment
+		// @Produce json
+		// @Param id query integer false "Comment ID for single fetch"
+		// @Param groupid query integer false "Filter by group ID"
+		// @Security BearerAuth
+		// @Success 200 {object} map[string]interface{}
+		rg.Get("/comment", comment.Get)
+
 		// Comment Write Operations
 		// @Router /comment [post]
 		// @Summary Create a comment on a user


### PR DESCRIPTION
## Summary
- Add GET /api/comment handler for listing and fetching user comments
- Single comment fetch via `?id=N` with moderator permission check
- Paginated list via `?groupid=N` with `context[reviewed]` cursor pagination
- Includes embedded `user` and `byuser` display names in response
- Admin/Support users can see all comments

## Test Plan
- [ ] Verify single comment fetch returns correct format
- [ ] Verify list pagination works with context parameter
- [ ] Verify moderator permission check
- [ ] CI tests pass

Companion client PR to follow in iznik-nuxt3.