### PR TITLE
feat: Add GET /noticeboard handler (V2 flat format)

### DIFF
--- a/router/routes.go
+++ b/router/routes.go
@@ -526,6 +526,22 @@ func SetupRoutes(app *fiber.App) {
 		// @Produce json
 		rg.Patch("/group", group.PatchGroup)
 
+		// Noticeboard GET (list)
+		// @Router /noticeboard [get]
+		// @Summary List noticeboards
+		// @Description Returns active noticeboards, optionally filtered by authority
+		// @Tags noticeboard
+		// @Produce json
+		rg.Get("/noticeboard", noticeboard.GetNoticeboard)
+
+		// Noticeboard GET (single)
+		// @Router /noticeboard/:id [get]
+		// @Summary Get noticeboard by ID
+		// @Description Returns noticeboard details with checks and photo
+		// @Tags noticeboard
+		// @Produce json
+		rg.Get("/noticeboard/:id", noticeboard.GetNoticeboard)
+
 		// Noticeboard POST (create + action)
 		// @Router /noticeboard [post]
 		// @Summary Create noticeboard or perform action


### PR DESCRIPTION
## Summary
- Add `GET /noticeboard/:id` for single noticeboard with checks and photo
- Add `GET /noticeboard` for list with optional `authorityid` filter
- Returns flat V2 format: user IDs instead of nested user objects
- Client fetches user details separately via `/user/:id`

## Test plan
- [x] 6 new Go tests: single, not found, invalid ID, with photo, empty checks, list
- [ ] CI passes