### PR TITLE
feat: AI image review micro volunteering

### DIFF
--- a/microvolunteering/microvolunteering.go
+++ b/microvolunteering/microvolunteering.go
@@ -14,13 +14,22 @@ import (
 	"gorm.io/gorm"
 )
 
+// AIImageChallenge represents an AI image to review
+type AIImageChallenge struct {
+	ID         uint64 `json:"id"`
+	Name       string `json:"name"`
+	URL        string `json:"url"`
+	UsageCount uint64 `json:"usage_count"`
+}
+
 // Challenge represents a micro-volunteering challenge
 type Challenge struct {
-	Type   string      `json:"type"`
-	Msgid  *uint64     `json:"msgid,omitempty"`
-	Terms  []SearchTerm `json:"terms,omitempty"`
-	Photos []Photo     `json:"photos,omitempty"`
-	URL    *string     `json:"url,omitempty"`
+	Type    string            `json:"type"`
+	Msgid   *uint64           `json:"msgid,omitempty"`
+	Terms   []SearchTerm      `json:"terms,omitempty"`
+	Photos  []Photo           `json:"photos,omitempty"`
+	URL     *string           `json:"url,omitempty"`
+	AIImage *AIImageChallenge `json:"aiimage,omitempty"`
 }
 
 // SearchTerm represents a search term for matching
@@ -42,6 +51,7 @@ const (
 	ChallengePhotoRotate    = "PhotoRotate"
 	ChallengeSurvey         = "Survey2"
 	ChallengeInvite         = "Invite"
+	ChallengeAIImageReview  = "AIImageReview"
 )
 
 // Trust levels
@@ -55,8 +65,9 @@ const (
 
 // Microvolunteering quorum constants
 const (
-	ApprovalQuorum   = 2
-	DissentingQuorum = 3
+	ApprovalQuorum       = 2
+	DissentingQuorum     = 3
+	AIImageReviewQuorum  = 5
 )
 
 // GetChallenge returns a micro-volunteering challenge for the logged-in user
@@ -99,12 +110,14 @@ func GetChallenge(c *fiber.Ctx) error {
 			ChallengeInvite,
 			ChallengeCheckMessage,
 			ChallengePhotoRotate,
+			ChallengeAIImageReview,
 		}
 	} else {
 		challengeTypes = []string{
 			ChallengeInvite,
 			ChallengeCheckMessage,
 			ChallengePhotoRotate,
+			ChallengeAIImageReview,
 		}
 	}
 
@@ -162,6 +175,13 @@ func GetChallenge(c *fiber.Ctx) error {
 	// Try photo rotate challenge
 	if contains(challengeTypes, ChallengePhotoRotate) && len(groupIDs) > 0 {
 		if challenge := getPhotoRotateChallenge(db, userID, groupIDs); challenge != nil {
+			return c.JSON(challenge)
+		}
+	}
+
+	// Try AI image review challenge
+	if contains(challengeTypes, ChallengeAIImageReview) {
+		if challenge := getAIImageReviewChallenge(db, userID); challenge != nil {
 			return c.JSON(challenge)
 		}
 	}
@@ -431,17 +451,64 @@ func getPhotoRotateChallenge(db *gorm.DB, userID uint64, groupIDs []uint64) *Cha
 // Version is the current microvolunteering protocol version.
 const Version = 4
 
+// getAIImageReviewChallenge returns an AI image for the user to review.
+// Images are served in descending order of usage_count (most-used first),
+// skipping images the user has already reviewed and images that have reached quorum.
+func getAIImageReviewChallenge(db *gorm.DB, userID uint64) *Challenge {
+	type AIImageResult struct {
+		ID          uint64 `json:"id"`
+		Name        string `json:"name"`
+		Externaluid string `json:"externaluid"`
+		UsageCount  uint64 `json:"usage_count"`
+	}
+
+	var img AIImageResult
+
+	err := db.Raw(`
+		SELECT ai.id, ai.name, ai.externaluid, ai.usage_count
+		FROM ai_images ai
+		LEFT JOIN microactions ma ON ma.aiimageid = ai.id AND ma.userid = ? AND ma.actiontype = ?
+		WHERE ai.externaluid IS NOT NULL
+			AND ai.externaluid != ''
+			AND ma.id IS NULL
+			AND (SELECT COUNT(*) FROM microactions WHERE aiimageid = ai.id AND actiontype = ?) < ?
+		ORDER BY ai.usage_count DESC
+		LIMIT 1
+	`, userID, ChallengeAIImageReview, ChallengeAIImageReview, AIImageReviewQuorum).Scan(&img).Error
+
+	if err != nil || img.ID == 0 {
+		return nil
+	}
+
+	imagesHost := os.Getenv("IMAGES_HOST")
+	if imagesHost == "" {
+		imagesHost = "https://images.ilovefreegle.org"
+	}
+
+	return &Challenge{
+		Type: ChallengeAIImageReview,
+		AIImage: &AIImageChallenge{
+			ID:         img.ID,
+			Name:       img.Name,
+			URL:        imagesHost + "/" + img.Externaluid,
+			UsageCount: img.UsageCount,
+		},
+	}
+}
+
 // PostResponseRequest represents the body for POST /microvolunteering
 type PostResponseRequest struct {
-	Msgid       uint64  `json:"msgid"`
-	MsgCategory *string `json:"msgcategory,omitempty"`
-	Response    *string `json:"response,omitempty"`
-	Comments    *string `json:"comments,omitempty"`
-	Searchterm1 uint64  `json:"searchterm1"`
-	Searchterm2 uint64  `json:"searchterm2"`
-	Photoid     uint64  `json:"photoid"`
-	Invite      bool    `json:"invite"`
-	Deg         int     `json:"deg"`
+	Msgid          uint64  `json:"msgid"`
+	MsgCategory    *string `json:"msgcategory,omitempty"`
+	Response       *string `json:"response,omitempty"`
+	Comments       *string `json:"comments,omitempty"`
+	Searchterm1    uint64  `json:"searchterm1"`
+	Searchterm2    uint64  `json:"searchterm2"`
+	Photoid        uint64  `json:"photoid"`
+	Invite         bool    `json:"invite"`
+	Deg            int     `json:"deg"`
+	AIImageID      uint64  `json:"aiimageid"`
+	ContainsPeople *bool   `json:"containspeople,omitempty"`
 }
 
 // PostResponse records a user's response to a micro-volunteering challenge
@@ -549,6 +616,29 @@ func PostResponse(c *fiber.Ctx) error {
 		}
 
 		return c.JSON(fiber.Map{"ret": 0, "status": "Success", "rotated": rotated})
+
+	} else if req.AIImageID > 0 && req.Response != nil {
+		// Response to an AIImageReview challenge.
+		response := *req.Response
+
+		if response == "Approve" || response == "Reject" {
+			var containsPeople interface{}
+			if req.ContainsPeople != nil {
+				if *req.ContainsPeople {
+					containsPeople = 1
+				} else {
+					containsPeople = 0
+				}
+			}
+
+			db.Exec(`INSERT INTO microactions (actiontype, userid, aiimageid, result, containspeople, version)
+				VALUES (?, ?, ?, ?, ?, ?)
+				ON DUPLICATE KEY UPDATE result = ?, containspeople = ?, version = ?`,
+				ChallengeAIImageReview, myid, req.AIImageID, response, containsPeople, Version,
+				response, containsPeople, Version)
+		}
+
+		return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 
 	} else if req.Invite {
 		// Response to an Invite challenge.

--- a/test/microvolunteering_ai_image_test.go
+++ b/test/microvolunteering_ai_image_test.go
@@ -1,0 +1,280 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/microvolunteering"
+	"github.com/stretchr/testify/assert"
+)
+
+// createTestAIImage inserts a test AI image and returns its ID. Cleanup is registered via t.Cleanup.
+func createTestAIImage(t *testing.T, name string, usageCount int) uint64 {
+	db := database.DBConn
+	uid := "freegletusd-test-" + name
+
+	db.Exec("INSERT INTO ai_images (name, externaluid, usage_count) VALUES (?, ?, ?)", name, uid, usageCount)
+
+	var id uint64
+	db.Raw("SELECT id FROM ai_images WHERE name = ? ORDER BY id DESC LIMIT 1", name).Scan(&id)
+	assert.NotZero(t, id, "Failed to create test AI image")
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM ai_images WHERE id = ?", id)
+	})
+
+	return id
+}
+
+// blockInviteChallenge prevents the invite challenge from being served, so we get to the AI image challenge.
+func blockInviteChallenge(t *testing.T, userID uint64) {
+	db := database.DBConn
+	db.Exec("INSERT INTO microactions (actiontype, userid, version, comments, timestamp, result) VALUES (?, ?, 4, 'Test block', NOW(), 'Approve')",
+		microvolunteering.ChallengeInvite, userID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM microactions WHERE userid = ? AND actiontype = ?", userID, microvolunteering.ChallengeInvite)
+	})
+}
+
+func TestAIImageReview_GetChallenge(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_aiimg")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	// Block invite + ensure no group (so no CheckMessage/PhotoRotate challenges).
+	blockInviteChallenge(t, userID)
+
+	// Create a test AI image with high usage.
+	imgID := createTestAIImage(t, "test-sofa-"+prefix, 100)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/microvolunteering?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result microvolunteering.Challenge
+	json2.Unmarshal(rsp(resp), &result)
+
+	assert.Equal(t, microvolunteering.ChallengeAIImageReview, result.Type)
+	assert.NotNil(t, result.AIImage)
+	assert.Equal(t, imgID, result.AIImage.ID)
+	assert.Equal(t, "test-sofa-"+prefix, result.AIImage.Name)
+	assert.Contains(t, result.AIImage.URL, "freegletusd-test-test-sofa-"+prefix)
+	assert.Equal(t, uint64(100), result.AIImage.UsageCount)
+
+	// Cleanup microactions created by the challenge (invite placeholder won't be created since we blocked it).
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM microactions WHERE userid = ? AND actiontype = ?", userID, microvolunteering.ChallengeAIImageReview)
+	})
+}
+
+func TestAIImageReview_UsageCountOrder(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_aiord")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+	blockInviteChallenge(t, userID)
+
+	// Create two AI images — higher usage should be served first.
+	createTestAIImage(t, "low-use-"+prefix, 5)
+	highID := createTestAIImage(t, "high-use-"+prefix, 500)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/microvolunteering?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result microvolunteering.Challenge
+	json2.Unmarshal(rsp(resp), &result)
+
+	assert.Equal(t, microvolunteering.ChallengeAIImageReview, result.Type)
+	assert.Equal(t, highID, result.AIImage.ID, "Higher usage image should be served first")
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM microactions WHERE userid = ? AND actiontype = ?", userID, microvolunteering.ChallengeAIImageReview)
+	})
+}
+
+func TestAIImageReview_PostResponse(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_aipost")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	imgID := createTestAIImage(t, "test-chair-"+prefix, 50)
+
+	body := fmt.Sprintf(`{"aiimageid":%d,"response":"Approve","containspeople":false}`, imgID)
+	req := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+token, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	// Verify the microaction was recorded correctly.
+	var actionType, actionResult string
+	var containsPeople int
+	db.Raw("SELECT actiontype, result, COALESCE(containspeople, -1) FROM microactions WHERE userid = ? AND aiimageid = ? ORDER BY id DESC LIMIT 1",
+		userID, imgID).Row().Scan(&actionType, &actionResult, &containsPeople)
+	assert.Equal(t, microvolunteering.ChallengeAIImageReview, actionType)
+	assert.Equal(t, "Approve", actionResult)
+	assert.Equal(t, 0, containsPeople, "containspeople should be false (0)")
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM microactions WHERE userid = ? AND actiontype = ?", userID, microvolunteering.ChallengeAIImageReview)
+	})
+}
+
+func TestAIImageReview_PostResponseWithPeople(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_aipeople")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	imgID := createTestAIImage(t, "test-desk-"+prefix, 30)
+
+	body := fmt.Sprintf(`{"aiimageid":%d,"response":"Reject","containspeople":true}`, imgID)
+	req := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+token, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Verify.
+	var containsPeople int
+	var actionResult string
+	db.Raw("SELECT result, COALESCE(containspeople, -1) FROM microactions WHERE userid = ? AND aiimageid = ? ORDER BY id DESC LIMIT 1",
+		userID, imgID).Row().Scan(&actionResult, &containsPeople)
+	assert.Equal(t, "Reject", actionResult)
+	assert.Equal(t, 1, containsPeople, "containspeople should be true (1)")
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM microactions WHERE userid = ? AND actiontype = ?", userID, microvolunteering.ChallengeAIImageReview)
+	})
+}
+
+func TestAIImageReview_NoDuplicateVote(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_aidedup")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+	blockInviteChallenge(t, userID)
+
+	imgID := createTestAIImage(t, "test-lamp-"+prefix, 20)
+
+	// First vote.
+	body := fmt.Sprintf(`{"aiimageid":%d,"response":"Approve","containspeople":false}`, imgID)
+	req := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+token, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Second vote — should update, not create duplicate.
+	body2 := fmt.Sprintf(`{"aiimageid":%d,"response":"Reject","containspeople":true}`, imgID)
+	req2 := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+token, strings.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, _ := getApp().Test(req2)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	// Should have exactly one row.
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM microactions WHERE userid = ? AND aiimageid = ?", userID, imgID).Scan(&count)
+	assert.Equal(t, int64(1), count, "Should have exactly one vote per user per image")
+
+	// Should be updated to Reject.
+	var actionResult string
+	db.Raw("SELECT result FROM microactions WHERE userid = ? AND aiimageid = ?", userID, imgID).Scan(&actionResult)
+	assert.Equal(t, "Reject", actionResult)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM microactions WHERE userid = ? AND actiontype = ?", userID, microvolunteering.ChallengeAIImageReview)
+	})
+}
+
+func TestAIImageReview_QuorumReached(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_aiquor")
+
+	// Create 6 users — 5 will vote, 1 will check that the image is no longer served.
+	var voters []uint64
+	var voterTokens []string
+	for i := 0; i < 5; i++ {
+		uid := CreateTestUser(t, fmt.Sprintf("%s_v%d", prefix, i), "User")
+		_, tok := CreateTestSession(t, uid)
+		voters = append(voters, uid)
+		voterTokens = append(voterTokens, tok)
+	}
+
+	checkerID := CreateTestUser(t, prefix+"_checker", "User")
+	_, checkerToken := CreateTestSession(t, checkerID)
+	blockInviteChallenge(t, checkerID)
+
+	imgID := createTestAIImage(t, "test-table-"+prefix, 200)
+
+	// Have 5 users vote.
+	for i := 0; i < 5; i++ {
+		body := fmt.Sprintf(`{"aiimageid":%d,"response":"Approve","containspeople":false}`, imgID)
+		req := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+voterTokens[i], strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := getApp().Test(req)
+		assert.Equal(t, 200, resp.StatusCode)
+	}
+
+	// Verify 5 votes recorded.
+	var voteCount int64
+	db.Raw("SELECT COUNT(*) FROM microactions WHERE aiimageid = ? AND actiontype = ?",
+		imgID, microvolunteering.ChallengeAIImageReview).Scan(&voteCount)
+	assert.Equal(t, int64(5), voteCount)
+
+	// The checker should NOT get this image since quorum is reached.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/microvolunteering?jwt="+checkerToken, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	// Either no challenge or a different type — not this image.
+	if typ, ok := result["type"]; ok {
+		if typ == microvolunteering.ChallengeAIImageReview {
+			aiimage := result["aiimage"].(map[string]interface{})
+			assert.NotEqual(t, float64(imgID), aiimage["id"], "Image at quorum should not be served")
+		}
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM microactions WHERE aiimageid = ? AND actiontype = ?", imgID, microvolunteering.ChallengeAIImageReview)
+	})
+}
+
+func TestAIImageReview_SkipAlreadyReviewed(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_aiskip")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+	blockInviteChallenge(t, userID)
+
+	// Create two images.
+	reviewedID := createTestAIImage(t, "reviewed-"+prefix, 100)
+	unreviewed := createTestAIImage(t, "unreviewed-"+prefix, 50)
+
+	// User has already reviewed the first image.
+	db.Exec("INSERT INTO microactions (actiontype, userid, aiimageid, result, version) VALUES (?, ?, ?, 'Approve', 4)",
+		microvolunteering.ChallengeAIImageReview, userID, reviewedID)
+
+	// Should get the unreviewed image.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/microvolunteering?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result microvolunteering.Challenge
+	json2.Unmarshal(rsp(resp), &result)
+
+	assert.Equal(t, microvolunteering.ChallengeAIImageReview, result.Type)
+	assert.Equal(t, unreviewed, result.AIImage.ID, "Should skip already-reviewed image")
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM microactions WHERE userid = ? AND actiontype = ?", userID, microvolunteering.ChallengeAIImageReview)
+	})
+}


### PR DESCRIPTION
## Summary
- New `AIImageReview` challenge type in microvolunteering system
- Serves AI images from `ai_images` table in descending `usage_count` order
- Records votes with `containspeople` flag, quorum at 5 votes per image
- 7 Go test cases covering serving, response, dedup, quorum, usage ordering

## Schema Changes Required
```sql
ALTER TABLE microactions 
  MODIFY COLUMN actiontype ENUM('CheckMessage','SearchTerm','Items','FacebookShare','PhotoRotate','ItemSize','ItemWeight','Survey','Survey2','Invite','AIImageReview'),
  ADD COLUMN aiimageid BIGINT UNSIGNED NULL DEFAULT NULL,
  ADD COLUMN containspeople TINYINT(1) NULL DEFAULT NULL,
  ADD INDEX idx_aiimageid (aiimageid),
  ADD UNIQUE KEY userid_6 (userid, aiimageid);

ALTER TABLE ai_images 
  ADD COLUMN usage_count INT UNSIGNED NOT NULL DEFAULT 0,
  ADD INDEX idx_usage_count (usage_count);
```

## Test plan
- [x] All 7 new Go tests pass
- [x] All 14 existing microvol Go tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)