### PR TITLE
fix(chat): mod opens member's User2Mod chat, search by email/name

### DIFF
--- a/chat/chatroom.go
+++ b/chat/chatroom.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/freegle/iznik-server-go/auth"
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/utils"
@@ -382,13 +383,18 @@ func PutChatRoom(c *fiber.Ctx) error {
 	now := time.Now()
 
 	if chattype == utils.CHAT_TYPE_USER2MOD {
-		// any logged-in user can contact a group's volunteers,
-		// even if they're not a member. This is intentional — users may need
-		// to contact volunteers before joining, or about a post they've seen.
-		// Find or create a chat between this user and the group's mods.
+		// Determine the target user for this User2Mod chat.
+		// If a moderator provides userid, they want to open the MEMBER's existing
+		// chat (e.g. from ModTools Feedback page). Non-mods always get their own chat.
+		chatUserID := myid
+		if req.Userid > 0 && req.Userid != myid && auth.IsModOfGroup(myid, req.Groupid) {
+			chatUserID = req.Userid
+		}
+
+		// Find or create a chat between the target user and the group's mods.
 		var existingID uint64
 		db.Raw("SELECT id FROM chat_rooms WHERE user1 = ? AND chattype = ? AND groupid = ? LIMIT 1",
-			myid, utils.CHAT_TYPE_USER2MOD, req.Groupid).Scan(&existingID)
+			chatUserID, utils.CHAT_TYPE_USER2MOD, req.Groupid).Scan(&existingID)
 
 		if existingID > 0 {
 			return c.JSON(fiber.Map{"ret": 0, "status": "Success", "id": existingID})
@@ -402,7 +408,7 @@ func PutChatRoom(c *fiber.Ctx) error {
 		sqlResult, err := sqlDB.Exec(
 			"INSERT INTO chat_rooms (user1, chattype, groupid, latestmessage) VALUES (?, ?, ?, ?) "+
 				"ON DUPLICATE KEY UPDATE id=LAST_INSERT_ID(id), latestmessage = VALUES(latestmessage)",
-			myid, utils.CHAT_TYPE_USER2MOD, req.Groupid, now)
+			chatUserID, utils.CHAT_TYPE_USER2MOD, req.Groupid, now)
 		if err != nil {
 			return fiber.NewError(fiber.StatusInternalServerError, "Failed to create chat room")
 		}
@@ -413,10 +419,10 @@ func PutChatRoom(c *fiber.Ctx) error {
 
 		chatID := uint64(lastID)
 
-		// Create roster entry for the user.
+		// Create roster entry for the chat owner.
 		db.Exec("INSERT INTO chat_roster (chatid, userid, status, date) VALUES (?, ?, ?, ?) "+
 			"ON DUPLICATE KEY UPDATE date = VALUES(date)",
-			chatID, myid, utils.CHAT_STATUS_ONLINE, now)
+			chatID, chatUserID, utils.CHAT_STATUS_ONLINE, now)
 
 		// add ALL group moderators to the roster so they get notifications.
 		var modIDs []uint64
@@ -728,7 +734,7 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 		for _, ct := range chattypes {
 			switch ct {
 			case utils.CHAT_TYPE_USER2USER:
-				// Search User2User chats where user is user1.
+				// Search User2User chats where user is user1 — by message content/subject.
 				unions = append(unions,
 					"SELECT 1 AS search, user2 AS otheruid, '' AS nameshort, '' AS namefull, firstname, lastname, fullname, users.deleted AS otherdeleted, "+
 						atts+", c1.status, NULL AS lasttype FROM chat_rooms "+
@@ -740,7 +746,18 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 						"AND (chat_messages.message LIKE ? OR messages.subject LIKE ?) ")
 				params = append(params, myid, myid, utils.CHAT_TYPE_USER2USER, searchLike, searchLike)
 
-				// Search User2User chats where user is user2.
+				// Search User2User chats where user is user1 — by other user's name/email.
+				unions = append(unions,
+					"SELECT 1 AS search, user2 AS otheruid, '' AS nameshort, '' AS namefull, firstname, lastname, fullname, users.deleted AS otherdeleted, "+
+						atts+", c1.status, NULL AS lasttype FROM chat_rooms "+
+						"LEFT JOIN chat_roster c1 ON c1.userid = ? AND chat_rooms.id = c1.chatid "+
+						"INNER JOIN users ON users.id = user2 "+
+						"LEFT JOIN users_emails ON users_emails.userid = user2 "+
+						"WHERE user1 = ? AND user1 != user2 AND chattype = ? "+onlyChatq+" "+
+						"AND (users.fullname LIKE ? OR users_emails.email LIKE ?) ")
+				params = append(params, myid, myid, utils.CHAT_TYPE_USER2USER, searchLike, searchLike)
+
+				// Search User2User chats where user is user2 — by message content/subject.
 				unions = append(unions,
 					"SELECT 1 AS search, user1 AS otheruid, '' AS nameshort, '' AS namefull, firstname, lastname, fullname, users.deleted AS otherdeleted, "+
 						atts+", c1.status, c2.lasttype FROM chat_rooms "+
@@ -753,9 +770,21 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 						"AND (chat_messages.message LIKE ? OR messages.subject LIKE ?) ")
 				params = append(params, myid, myid, utils.CHAT_TYPE_USER2USER, searchLike, searchLike)
 
+				// Search User2User chats where user is user2 — by other user's name/email.
+				unions = append(unions,
+					"SELECT 1 AS search, user1 AS otheruid, '' AS nameshort, '' AS namefull, firstname, lastname, fullname, users.deleted AS otherdeleted, "+
+						atts+", c1.status, c2.lasttype FROM chat_rooms "+
+						"LEFT JOIN chat_roster c1 ON c1.userid = ? AND chat_rooms.id = c1.chatid "+
+						"LEFT JOIN chat_roster c2 ON c2.userid = user1 AND chat_rooms.id = c2.chatid "+
+						"INNER JOIN users ON users.id = user1 "+
+						"LEFT JOIN users_emails ON users_emails.userid = user1 "+
+						"WHERE user2 = ? AND user1 != user2 AND chattype = ? "+onlyChatq+" "+
+						"AND (users.fullname LIKE ? OR users_emails.email LIKE ?) ")
+				params = append(params, myid, myid, utils.CHAT_TYPE_USER2USER, searchLike, searchLike)
+
 			case utils.CHAT_TYPE_USER2MOD:
 				if memberOnly {
-					// Freegle: search only User2Mod chats where we are the member.
+					// Freegle: search only User2Mod chats where we are the member — by message content/subject.
 					unions = append(unions,
 						"SELECT 1 AS search, user1 AS otheruid, nameshort, namefull, "+
 							"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS firstname, "+
@@ -773,7 +802,7 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 							"AND (chat_messages.message LIKE ? OR messages.subject LIKE ?) ")
 					params = append(params, myid, utils.CHAT_TYPE_USER2MOD, myid, searchLike, searchLike)
 				} else {
-					// ModTools: search User2Mod chats visible to user (as member or moderator).
+					// ModTools: search User2Mod chats visible to user — by message content/subject.
 					unions = append(unions,
 						"SELECT 1 AS search, user1 AS otheruid, nameshort, namefull, "+
 							"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS firstname, "+
@@ -790,10 +819,28 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 							onlyChatq+" "+
 							"AND (chat_messages.message LIKE ? OR messages.subject LIKE ?) ")
 					params = append(params, myid, utils.CHAT_TYPE_USER2MOD, myid, myid, utils.ROLE_MODERATOR, utils.ROLE_OWNER, searchLike, searchLike)
+
+					// ModTools: search User2Mod chats by member's name/email.
+					unions = append(unions,
+						"SELECT 1 AS search, user1 AS otheruid, nameshort, namefull, "+
+							"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS firstname, "+
+							"'' AS lastname, "+
+							"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS fullname, "+
+							"(SELECT deleted FROM users WHERE users.id = user1) AS otherdeleted, "+
+							atts+", c1.status, NULL AS lasttype FROM chat_rooms "+
+							"INNER JOIN `groups` ON groups.id = chat_rooms.groupid "+
+							"LEFT JOIN chat_roster c1 ON c1.userid = ? AND chat_rooms.id = c1.chatid "+
+							"INNER JOIN users ON users.id = user1 "+
+							"LEFT JOIN users_emails ON users_emails.userid = user1 "+
+							"WHERE chattype = ? "+
+							"AND (user1 = ? OR EXISTS(SELECT 1 FROM memberships WHERE memberships.userid = ? AND memberships.groupid = chat_rooms.groupid AND memberships.role IN (?, ?))) "+
+							onlyChatq+" "+
+							"AND (users.fullname LIKE ? OR users_emails.email LIKE ?) ")
+					params = append(params, myid, utils.CHAT_TYPE_USER2MOD, myid, myid, utils.ROLE_MODERATOR, utils.ROLE_OWNER, searchLike, searchLike)
 				}
 
 			case utils.CHAT_TYPE_MOD2MOD:
-				// Search Mod2Mod chats visible to user as moderator.
+				// Search Mod2Mod chats visible to user as moderator — by message content/subject.
 				unions = append(unions,
 					"SELECT 1 AS search, 0 AS otheruid, nameshort, namefull, '' AS firstname, '' AS lastname, '' AS fullname, NULL AS otherdeleted, "+
 						atts+", c1.status, NULL AS lasttype FROM chat_rooms "+

--- a/test/chat_test.go
+++ b/test/chat_test.go
@@ -2659,6 +2659,54 @@ func TestListChatsMTSearchUser2Mod(t *testing.T) {
 	assert.GreaterOrEqual(t, len(chatrooms), 1, "Search should find the User2Mod chat with 'Hello' message")
 }
 
+func TestListChatsMTSearchByEmail(t *testing.T) {
+	// Verify that searching by a user's email address finds their chat.
+	// Bug: Neville reported searching by email in chat search returns nothing.
+	prefix := uniquePrefix("SearchEmail")
+	modID, userID, _, _, _ := setupModChatData(t, prefix)
+	_ = userID
+
+	_, token := CreateTestSession(t, modID)
+
+	// The user's email is prefix_user@test.com — search for it.
+	email := prefix + "_user@test.com"
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/chat/rooms?chattypes=User2Mod&search=%s&jwt=%s", email, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Contains(t, result, "chatrooms")
+
+	chatrooms := result["chatrooms"].([]interface{})
+	assert.GreaterOrEqual(t, len(chatrooms), 1,
+		"Search by email should find the User2Mod chat for that user")
+}
+
+func TestListChatsMTSearchByDisplayName(t *testing.T) {
+	// Verify that searching by a user's display name finds their chat.
+	prefix := uniquePrefix("SearchName")
+	modID, _, groupID, _, _ := setupModChatData(t, prefix)
+	_ = groupID
+
+	_, token := CreateTestSession(t, modID)
+
+	// The user's fullname is "Test User prefix_user" — search for a unique part.
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/chat/rooms?chattypes=User2Mod&search=%s_user&jwt=%s", prefix, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Contains(t, result, "chatrooms")
+
+	chatrooms := result["chatrooms"].([]interface{})
+	assert.GreaterOrEqual(t, len(chatrooms), 1,
+		"Search by display name should find the User2Mod chat for that user")
+}
+
 func TestUnseenCountMTBackupModExcluded(t *testing.T) {
 	// Backup mods (active:0 in membership settings) should NOT see unseen counts for those groups.
 	prefix := uniquePrefix("BackupMod")
@@ -2945,6 +2993,105 @@ func TestPutChatRoomUser2Mod(t *testing.T) {
 	var result2 map[string]interface{}
 	json2.NewDecoder(resp2.Body).Decode(&result2)
 	assert.Equal(t, float64(chatID), result2["id"], "Should return existing chat on re-PUT")
+}
+
+func TestPutChatRoomUser2ModModOpensMemberChat(t *testing.T) {
+	// When a moderator opens a User2Mod chat with userid set, it should
+	// return the MEMBER's existing User2Mod chat, not create a new chat
+	// for the mod. This is used by ModTools Feedback page — the "Chat"
+	// button should open the member's conversation with the group.
+	prefix := uniquePrefix("putchat_u2m_mod")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+
+	// Create a member and a moderator.
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+	CreateTestMembership(t, memberID, groupID, "Member")
+	_, memberToken := CreateTestSession(t, memberID)
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Step 1: Member creates a User2Mod chat with the group.
+	payload := map[string]interface{}{
+		"chattype": "User2Mod",
+		"groupid":  groupID,
+	}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("PUT", "/api/chat/rooms?jwt="+memberToken, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var memberResult map[string]interface{}
+	json2.NewDecoder(resp.Body).Decode(&memberResult)
+	memberChatID := uint64(memberResult["id"].(float64))
+	assert.Greater(t, memberChatID, uint64(0))
+
+	// Verify the chat has user1 = member.
+	var user1 uint64
+	db.Raw("SELECT user1 FROM chat_rooms WHERE id = ?", memberChatID).Scan(&user1)
+	assert.Equal(t, memberID, user1, "Member's chat should have user1 = memberID")
+
+	// Step 2: Moderator opens a User2Mod chat with userid = memberID.
+	// This should return the MEMBER's existing chat, not create a new one.
+	modPayload := map[string]interface{}{
+		"chattype": "User2Mod",
+		"groupid":  groupID,
+		"userid":   memberID,
+	}
+	s2, _ := json2.Marshal(modPayload)
+	request2 := httptest.NewRequest("PUT", "/api/chat/rooms?jwt="+modToken, bytes.NewBuffer(s2))
+	request2.Header.Set("Content-Type", "application/json")
+	resp2, _ := getApp().Test(request2)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	var modResult map[string]interface{}
+	json2.NewDecoder(resp2.Body).Decode(&modResult)
+	modChatID := uint64(modResult["id"].(float64))
+
+	assert.Equal(t, memberChatID, modChatID,
+		"Mod opening User2Mod with userid should return the member's existing chat, not a new one")
+}
+
+func TestPutChatRoomUser2ModModOpensMemberChatNotMod(t *testing.T) {
+	// A non-mod providing userid on User2Mod should get their OWN chat,
+	// not the other user's chat. Only moderators can look up another user's chat.
+	prefix := uniquePrefix("putchat_u2m_notmod")
+
+	groupID := CreateTestGroup(t, prefix)
+
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+	CreateTestMembership(t, memberID, groupID, "Member")
+
+	otherID := CreateTestUser(t, prefix+"_other", "User")
+	CreateTestMembership(t, otherID, groupID, "Member")
+	_, otherToken := CreateTestSession(t, otherID)
+
+	// Non-mod sends userid — should be ignored, returns their own chat.
+	payload := map[string]interface{}{
+		"chattype": "User2Mod",
+		"groupid":  groupID,
+		"userid":   memberID,
+	}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("PUT", "/api/chat/rooms?jwt="+otherToken, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.NewDecoder(resp.Body).Decode(&result)
+	chatID := uint64(result["id"].(float64))
+
+	// Verify this is OTHER's chat, not member's.
+	db := database.DBConn
+	var user1 uint64
+	db.Raw("SELECT user1 FROM chat_rooms WHERE id = ?", chatID).Scan(&user1)
+	assert.Equal(t, otherID, user1,
+		"Non-mod should get their own User2Mod chat, not the member's")
 }
 
 func TestPutChatRoomUser2ModAllowsNonMember(t *testing.T) {


### PR DESCRIPTION
## Summary
- **Chat button on Feedback page** now opens the member's User2Mod chat instead of the mod's own group volunteers chat. When a mod provides `userid` param, `PutChatRoom` creates/finds the member's chat room. Non-mods cannot use this param (security check via `IsModOfGroup`).
- **Chat search by email/name** adds UNION branches to `ListChats` that search `users.fullname` and `users_emails.email`, not just message content. Covers User2User and User2Mod chat types.

## Test plan
- [x] `TestPutChatRoomUser2ModModOpensMemberChat` — mod opens member's chat, gets same room
- [x] `TestPutChatRoomUser2ModModOpensMemberChatNotMod` — non-mod can't use userid param
- [x] `TestListChatsMTSearchByEmail` — search finds chat by member email
- [x] `TestListChatsMTSearchByDisplayName` — search finds chat by member name
- [x] Full Go suite: 1329/1329 pass

Fixes: Discourse 9481.455-458, 9481.459