### PR TITLE
fix(message): V1 parity for edit reviewrequired logic

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -2299,17 +2299,50 @@ func PatchMessage(c *fiber.Ctx) error {
 			newLocationVal = current.Locationid
 		}
 
-		db.Exec("INSERT INTO messages_edits (msgid, byuser, oldsubject, newsubject, oldtype, newtype, oldtext, newtext, olditems, newitems, oldimages, newimages, oldlocation, newlocation, reviewrequired) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
-			req.ID, myid, oldSubject, newSubject, oldType, newType, oldText, newText, oldItemsVal, newItemsVal, oldImagesVal, newImagesVal, oldLocationVal, newLocationVal)
+		// V1 parity: reviewrequired is only set when the message is Approved
+		// AND the member's posting status would put them in Pending (i.e. they
+		// are moderated). Unmoderated members' edits go live with no review.
+		reviewRequired := 0
+		groupIDs := getAllGroupsForMessage(db, req.ID)
+
+		for _, gid := range groupIDs {
+			// Check if the message is currently Approved on this group.
+			var collection string
+			db.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", req.ID, gid).Scan(&collection)
+
+			if strings.EqualFold(collection, "Approved") {
+				// Check if the group is set to moderate all posts.
+				var groupModerated, groupClosed int
+				db.Raw("SELECT COALESCE(JSON_EXTRACT(settings, '$.moderated'), 0), COALESCE(JSON_EXTRACT(settings, '$.closed'), 0) FROM `groups` WHERE id = ?", gid).Row().Scan(&groupModerated, &groupClosed)
+
+				if groupModerated == 1 || groupClosed == 1 {
+					// Group moderates all posts — this edit needs review.
+					reviewRequired = 1
+				} else {
+					// Check the member's individual posting status.
+					var postingStatus *string
+					db.Raw("SELECT ourPostingStatus FROM memberships WHERE userid = ? AND groupid = ?", myid, gid).Scan(&postingStatus)
+
+					// NULL, empty, or MODERATED → member is moderated → review required.
+					if postingStatus == nil || *postingStatus == "" || strings.EqualFold(*postingStatus, "MODERATED") || strings.EqualFold(*postingStatus, "PROHIBITED") {
+						reviewRequired = 1
+					}
+				}
+			}
+		}
+
+		db.Exec("INSERT INTO messages_edits (msgid, byuser, oldsubject, newsubject, oldtype, newtype, oldtext, newtext, olditems, newitems, oldimages, newimages, oldlocation, newlocation, reviewrequired) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+			req.ID, myid, oldSubject, newSubject, oldType, newType, oldText, newText, oldItemsVal, newItemsVal, oldImagesVal, newImagesVal, oldLocationVal, newLocationVal, reviewRequired)
 		db.Exec("UPDATE messages SET editedby = ? WHERE id = ?", myid, req.ID)
 
-		// Issue 3: Notify group mods that an edit needs review.
-		groupIDs := getAllGroupsForMessage(db, req.ID)
-		for _, gid := range groupIDs {
-			if err := queue.QueueTask(queue.TaskPushNotifyGroupMods, map[string]interface{}{
-				"group_id": gid,
-			}); err != nil {
-				log.Printf("Failed to queue push notification for group %d on edit review: %v", gid, err)
+		// Only notify mods when review is required.
+		if reviewRequired == 1 {
+			for _, gid := range groupIDs {
+				if err := queue.QueueTask(queue.TaskPushNotifyGroupMods, map[string]interface{}{
+					"group_id": gid,
+				}); err != nil {
+					log.Printf("Failed to queue push notification for group %d on edit review: %v", gid, err)
+				}
 			}
 		}
 	}

--- a/test/message_test.go
+++ b/test/message_test.go
@@ -5593,3 +5593,160 @@ func TestGetMessagePostings(t *testing.T) {
 	assert.NotEmpty(t, posting["date"])
 	assert.NotEmpty(t, posting["namedisplay"])
 }
+
+func TestPatchMessageEditReviewRequiredModeratedMember(t *testing.T) {
+	// V1 parity: moderated member editing an APPROVED message → edit succeeds
+	// but reviewrequired=1 in messages_edits (mod gets notified to review).
+	prefix := uniquePrefix("msgedit_review_mod")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+
+	// Set member to moderated posting status.
+	db.Exec("UPDATE memberships SET ourPostingStatus = 'MODERATED' WHERE userid = ? AND groupid = ?", ownerID, groupID)
+
+	// Create an APPROVED message (edits of approved messages by moderated members need review).
+	msgID := createPendingMessage(t, ownerID, groupID, prefix)
+	db.Exec("UPDATE messages_groups SET collection = 'Approved' WHERE msgid = ? AND groupid = ?", msgID, groupID)
+
+	// Clean up any prior edits for this message.
+	db.Exec("DELETE FROM messages_edits WHERE msgid = ?", msgID)
+
+	body := map[string]interface{}{
+		"id":      msgID,
+		"subject": prefix + " edited subject",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Edit should succeed (not blocked)")
+
+	// Verify reviewrequired=1 was set in messages_edits.
+	var reviewRequired int
+	db.Raw("SELECT reviewrequired FROM messages_edits WHERE msgid = ? ORDER BY id DESC LIMIT 1", msgID).Scan(&reviewRequired)
+	assert.Equal(t, 1, reviewRequired, "Moderated member editing approved message should set reviewrequired=1")
+}
+
+func TestPatchMessageEditNoReviewUnmoderatedMember(t *testing.T) {
+	// V1 parity: unmoderated (DEFAULT) member editing an APPROVED message → edit succeeds
+	// and reviewrequired=0 (no mod notification needed).
+	prefix := uniquePrefix("msgedit_noreview_unmod")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+
+	// Set member to DEFAULT posting status (unmoderated).
+	db.Exec("UPDATE memberships SET ourPostingStatus = 'DEFAULT' WHERE userid = ? AND groupid = ?", ownerID, groupID)
+
+	// Ensure the group is NOT moderated.
+	db.Exec("UPDATE `groups` SET settings = JSON_SET(COALESCE(settings, '{}'), '$.moderated', 0, '$.closed', 0) WHERE id = ?", groupID)
+
+	// Create an APPROVED message.
+	msgID := createPendingMessage(t, ownerID, groupID, prefix)
+	db.Exec("UPDATE messages_groups SET collection = 'Approved' WHERE msgid = ? AND groupid = ?", msgID, groupID)
+
+	// Clean up any prior edits.
+	db.Exec("DELETE FROM messages_edits WHERE msgid = ?", msgID)
+
+	body := map[string]interface{}{
+		"id":      msgID,
+		"subject": prefix + " edited subject",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Edit should succeed")
+
+	// Verify reviewrequired=0 (no review needed for unmoderated member).
+	var reviewRequired int
+	db.Raw("SELECT reviewrequired FROM messages_edits WHERE msgid = ? ORDER BY id DESC LIMIT 1", msgID).Scan(&reviewRequired)
+	assert.Equal(t, 0, reviewRequired, "Unmoderated member editing approved message should set reviewrequired=0")
+}
+
+func TestPatchMessageEditNoReviewPendingMessage(t *testing.T) {
+	// V1 parity: moderated member editing a PENDING message → edit succeeds
+	// and reviewrequired=0 (message isn't approved yet, so no retrospective review needed).
+	prefix := uniquePrefix("msgedit_noreview_pend")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+
+	// Set member to moderated posting status.
+	db.Exec("UPDATE memberships SET ourPostingStatus = 'MODERATED' WHERE userid = ? AND groupid = ?", ownerID, groupID)
+
+	// Create a PENDING message (stays as Pending from createPendingMessage).
+	msgID := createPendingMessage(t, ownerID, groupID, prefix)
+
+	// Clean up any prior edits.
+	db.Exec("DELETE FROM messages_edits WHERE msgid = ?", msgID)
+
+	body := map[string]interface{}{
+		"id":      msgID,
+		"subject": prefix + " edited subject",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Edit should succeed")
+
+	// Verify reviewrequired=0 (pending messages don't need review — they're already pending).
+	var reviewRequired int
+	db.Raw("SELECT reviewrequired FROM messages_edits WHERE msgid = ? ORDER BY id DESC LIMIT 1", msgID).Scan(&reviewRequired)
+	assert.Equal(t, 0, reviewRequired, "Moderated member editing pending message should set reviewrequired=0")
+}
+
+func TestPatchMessageEditReviewRequiredGroupModerated(t *testing.T) {
+	// V1 parity: when the GROUP is set to moderate all posts, even a DEFAULT-status
+	// member's edit of an approved message should set reviewrequired=1.
+	prefix := uniquePrefix("msgedit_review_grpmod")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+
+	// Member has DEFAULT posting status (normally unmoderated).
+	db.Exec("UPDATE memberships SET ourPostingStatus = 'DEFAULT' WHERE userid = ? AND groupid = ?", ownerID, groupID)
+
+	// But the group itself is set to moderate all posts.
+	db.Exec("UPDATE `groups` SET settings = JSON_SET(COALESCE(settings, '{}'), '$.moderated', 1) WHERE id = ?", groupID)
+
+	// Create an APPROVED message.
+	msgID := createPendingMessage(t, ownerID, groupID, prefix)
+	db.Exec("UPDATE messages_groups SET collection = 'Approved' WHERE msgid = ? AND groupid = ?", msgID, groupID)
+
+	// Clean up any prior edits.
+	db.Exec("DELETE FROM messages_edits WHERE msgid = ?", msgID)
+
+	body := map[string]interface{}{
+		"id":      msgID,
+		"subject": prefix + " edited subject",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Edit should succeed")
+
+	// Verify reviewrequired=1 (group-level moderation overrides individual status).
+	var reviewRequired int
+	db.Raw("SELECT reviewrequired FROM messages_edits WHERE msgid = ? ORDER BY id DESC LIMIT 1", msgID).Scan(&reviewRequired)
+	assert.Equal(t, 1, reviewRequired, "Group-moderated edit of approved message should set reviewrequired=1")
+}


### PR DESCRIPTION
## Summary
- V2 was hardcoding `reviewrequired=1` for all non-mod edits, causing mods to be notified about every edit regardless of member status
- V1 only flags edits for review when the message is **Approved** AND the member is **moderated** (individual posting status or group-level moderation)
- Unmoderated members' edits go live without mod notification — matching V1 behavior

## Logic
| Message state | Member status | reviewrequired |
|--------------|---------------|---------------|
| Approved | MODERATED / PROHIBITED / NULL | 1 |
| Approved | DEFAULT (unmoderated group) | 0 |
| Approved | Any (group-moderated) | 1 |
| Pending | Any | 0 |

## Test plan
- [x] `TestPatchMessageEditReviewRequiredModeratedMember` — moderated member edits approved msg → reviewrequired=1
- [x] `TestPatchMessageEditNoReviewUnmoderatedMember` — DEFAULT member edits approved msg → reviewrequired=0
- [x] `TestPatchMessageEditNoReviewPendingMessage` — moderated member edits pending msg → reviewrequired=0
- [x] `TestPatchMessageEditReviewRequiredGroupModerated` — DEFAULT member on group-moderated group → reviewrequired=1
- [x] Full test suite: 1329 passed, 0 failed