### PR TITLE
fix: mark deploy:watch as inactive in cron job registry

### DIFF
--- a/housekeeper/housekeeper.go
+++ b/housekeeper/housekeeper.go
@@ -260,7 +260,7 @@ type cronJobStatus struct {
 // cronJobs is the static registry of all Laravel scheduled commands.
 var cronJobs = []CronJob{
 	// System
-	{Command: "deploy:watch", Name: "Deployment Watcher", Description: "Detects code updates and auto-refreshes application", Schedule: "Every minute", IntervalMinutes: 1, Category: "System", Active: true},
+	{Command: "deploy:watch", Name: "Deployment Watcher", Description: "Detects code updates and auto-refreshes application", Schedule: "Every minute", IntervalMinutes: 1, Category: "System", Active: false},
 	{Command: "queue:background-tasks", Name: "Background Task Queue", Description: "Processes tasks queued by Go API (push notifications, emails)", Schedule: "Every minute", IntervalMinutes: 1, Category: "System", Active: true},
 
 	// Email — Chat Notifications

--- a/test/housekeeper_test.go
+++ b/test/housekeeper_test.go
@@ -433,3 +433,31 @@ func TestSessionWorkIncludesHousekeeping(t *testing.T) {
 	// Clean up.
 	db.Exec("DELETE FROM housekeeper_tasks WHERE task_key IN (?, ?)", prefix+"_failed", prefix+"_overdue")
 }
+
+func TestDeployWatchIsInactive(t *testing.T) {
+	// deploy:watch has been disabled — verify ActiveCronJobCount does not include it,
+	// and that it appears as Active: false in the cron job list.
+	prefix := uniquePrefix("deployw")
+	userID := CreateTestUser(t, prefix+"_admin", "Admin")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, userID, groupID, "Moderator")
+	_, token := CreateTestSession(t, userID)
+
+	req := httptest.NewRequest("GET", "/api/housekeeper/cronjobs?jwt="+token, nil)
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var jobs []map[string]interface{}
+	err = json.Unmarshal(respBody, &jobs)
+	assert.NoError(t, err)
+
+	for _, job := range jobs {
+		if job["command"] == "deploy:watch" {
+			active, ok := job["active"].(bool)
+			assert.True(t, ok, "active field should be a boolean")
+			assert.False(t, active, "deploy:watch should be inactive")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- deploy:watch has been disabled in the Laravel scheduler but was still listed as Active: true in the Go cron job registry
- This caused it to count as never run and inflate the cronjobs work count in the sysadmin badge
- Changed to Active: false to match actual scheduler state

## Test plan
- Added TestDeployWatchIsInactive test verifying deploy:watch appears as inactive in the cron job list

🤖 Generated with [Claude Code](https://claude.com/claude-code)