### PR TITLE
fix(isochrone): read id from JSON body in DELETE handler

### DIFF
--- a/isochrone/isochrone.go
+++ b/isochrone/isochrone.go
@@ -318,7 +318,17 @@ func DeleteIsochrone(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
 	}
 
-	id, _ := strconv.ParseUint(c.Query("id", "0"), 10, 64)
+	type DeleteRequest struct {
+		ID utils.FlexUint64 `json:"id"`
+	}
+
+	var req DeleteRequest
+	_ = c.BodyParser(&req)
+
+	id := uint64(req.ID)
+	if id == 0 {
+		id, _ = strconv.ParseUint(c.FormValue("id", c.Query("id", "0")), 10, 64)
+	}
 	if id == 0 {
 		return fiber.NewError(fiber.StatusBadRequest, "Missing id")
 	}

--- a/test/isochrone_test.go
+++ b/test/isochrone_test.go
@@ -127,6 +127,36 @@ func TestDeleteIsochrone(t *testing.T) {
 	assert.Equal(t, int64(0), count)
 }
 
+func TestDeleteIsochroneBodyID(t *testing.T) {
+	// The client sends DELETE with id in the JSON body, not the query string.
+	// This must work — the handler should read from body, not just query.
+	prefix := uniquePrefix("IsoDelBody")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	CreateTestIsochrone(t, userID, 55.9533, -3.1883)
+
+	db := database.DBConn
+	var isoUserID uint64
+	db.Raw("SELECT id FROM isochrones_users WHERE userid = ? ORDER BY id DESC LIMIT 1", userID).Scan(&isoUserID)
+	assert.Greater(t, isoUserID, uint64(0))
+
+	body := fmt.Sprintf(`{"id":%d}`, isoUserID)
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/isochrone?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode, "DELETE should accept id from JSON body")
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	// Verify deleted.
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM isochrones_users WHERE id = ?", isoUserID).Scan(&count)
+	assert.Equal(t, int64(0), count)
+}
+
 func TestDeleteIsochroneWrongUser(t *testing.T) {
 	prefix := uniquePrefix("IsoDelWrong")
 	ownerID := CreateTestUser(t, prefix+"_owner", "User")


### PR DESCRIPTION
## Summary
- DELETE /isochrone only read `id` from query string (`c.Query`), but the client sends it in the JSON body
- Every delete request returned 400 "Missing id" — the endpoint was completely broken
- Now uses `BodyParser` (like EditIsochrone/PATCH) with fallback to FormValue and Query

## Test plan
- [x] Added `TestDeleteIsochroneBodyID` — sends id in JSON body, verifies 200 and record deleted
- [x] Existing `TestDeleteIsochrone` (query string) still passes
- [x] All Go tests pass (1325 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)